### PR TITLE
Make serde and rustc-serialize optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,14 @@ documentation = "http://docs.rs/string-intern"
 version = "0.1.6"
 authors = ["paul@colomiets.name"]
 
+[features]
+default = ["rustc-serialize", "serde"]
+
 [dependencies]
 lazy_static = "0.2.1"
-rustc-serialize = "0.3.19"
-serde = "1.0.8"
+
+rustc-serialize = { version = "0.3.19", optional = true }
+serde = { version = "1.0.8", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.2"

--- a/src/base_type.rs
+++ b/src/base_type.rs
@@ -9,9 +9,9 @@ use std::sync::{Arc, RwLock, Weak};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 
-use serde::ser::{Serialize, Serializer};
-use serde::de::{self, Deserialize, Deserializer, Visitor};
-use rustc_serialize::{Decoder, Decodable, Encoder, Encodable};
+#[cfg(feature = "serde")] use serde::ser::{Serialize, Serializer};
+#[cfg(feature = "serde")] use serde::de::{self, Deserialize, Deserializer, Visitor};
+#[cfg(feature = "rustc-serialize")] use rustc_serialize::{Decoder, Decodable, Encoder, Encodable};
 use {Validator};
 
 lazy_static! {
@@ -152,6 +152,7 @@ impl<V: Validator + ?Sized> fmt::Display for Symbol<V> {
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl<V: Validator> Decodable for Symbol<V> {
     fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
         use std::error::Error;
@@ -161,14 +162,17 @@ impl<V: Validator> Decodable for Symbol<V> {
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl<V: Validator> Encodable for Symbol<V> {
     fn encode<E: Encoder>(&self, d: &mut E) -> Result<(), E::Error> {
         d.emit_str(&(self.0).0)
     }
 }
 
+#[cfg(feature = "serde")]
 struct SymbolVisitor<V: Validator>(PhantomData<V>);
 
+#[cfg(feature = "serde")]
 impl<'de, V: Validator> Visitor<'de> for SymbolVisitor<V> {
     type Value = Symbol<V>;
 
@@ -182,6 +186,8 @@ impl<'de, V: Validator> Visitor<'de> for SymbolVisitor<V> {
         v.parse().map_err(de::Error::custom)
     }
 }
+
+#[cfg(feature = "serde")]
 impl<'de, V: Validator> Deserialize<'de> for Symbol<V> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: Deserializer<'de>
@@ -190,6 +196,7 @@ impl<'de, V: Validator> Deserialize<'de> for Symbol<V> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<V: Validator> Serialize for Symbol<V> {
     fn serialize<S: Serializer>(&self, serializer: S)
         -> Result<S::Ok, S::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@
 //! assert!(x[..].as_bytes() as *const _ == y[..].as_bytes() as *const _);
 //! ```
 #[macro_use] extern crate lazy_static;
-extern crate rustc_serialize;
-extern crate serde;
+#[cfg(feature = "rustc-serialize")] extern crate rustc_serialize;
+#[cfg(feature = "serde")] extern crate serde;
 #[cfg(test)] extern crate serde_json;
 
 mod base_type;


### PR DESCRIPTION
This just adds some `cfg` directives to make both `serde` and `rustc-serialize` optional for those who don't need them.
They should still be enabled by default so it would be a safe upgrade for anyone using them.
I'm just trying to cut back on the dependencies my crate requires and removing `serde` is particularly desirable since it has a relatively long compliation time.