### PR TITLE
remove use of deprecated `should_panic` syntax

### DIFF
--- a/src/base_type.rs
+++ b/src/base_type.rs
@@ -311,7 +311,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(message="static strings used as atom is invalid")]
+    #[should_panic(expected="static string used as atom is invalid")]
     fn distinct_validators() {
         let _xa = Atom::from("x");
         let _xn = AlphaNum::from("x");


### PR DESCRIPTION
Hi there!

We recently redid how the `should_panic` attribute is parsed in the rust compiler. When we did so, we realized we were too permissive, and even when using the wrong syntax would allow so without any warning. We decided to fix this, which would break a few crates that accidentally used the wrong syntax. You're one of the lucky few! Congrats, hehe.

In your case, you were using `message = ...` which was silently ignored by the compiler. As such, the test wasn't testing what you wanted it to. This change should fix that :)

Relevant compiler PR introducing this change: https://github.com/rust-lang/rust/pull/143808
Issue tracking this regression: https://github.com/rust-lang/rust/issues/147969